### PR TITLE
Update Tasks to Use Wait For

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ Known issues with other distributions:
 
 See this [build](https://travis-ci.org/Duologic/ansible-role-sentry/builds/487380995).
 
+Testing
+-------
+Create a python [virtualenv](https://docs.python-guide.org/dev/virtualenvs/) and run
+```sh
+pip install molecule docker-py
+molecule test
+```
+
 License
 -------
 

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -38,9 +38,7 @@
         name: Duologic.sentry
 
   post_tasks:
-    - name: Wait for Sentry to leave the runway
-      pause:
-        seconds: 30
     - name: Check if Sentry is running.
-      uri:
-        url: "http://127.0.0.1:9000/"
+      wait_for:
+        port: 9000
+        delay: 30


### PR DESCRIPTION
- Update task to use Ansible's wait_for module to check if sentry is running
- Update docs to include how to test with molecule