### PR TITLE
Update Virtualenv Package

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
   apt: name={{ packages }} state=present
   vars:
       packages:
-          - python-virtualenv
+          - virtualenv
           - python-setuptools
           - python-dev
           - libxslt1-dev
@@ -24,7 +24,7 @@
   yum: name={{ packages }} state=present
   vars:
       packages:
-          - python-virtualenv
+          - virtualenv
           - python-setuptools
           - python-devel
           - gcc


### PR DESCRIPTION
Updates the virtualenv dependency from "python-virtualenv" to
"virtualenv" since "virtualenv":

1. Has "python-virtualenv" as a dependency
2. Installs /usr/bin/virtualenv (whilst python-virtualenv installs
   /usr/lib/python3/dist-packages/virtualenv.py)

Signed-off-by: Jason Rogena <jason@rogena.me>